### PR TITLE
feat(cli): filter by prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Options:
   --only-admin          only consider repositories you can delete
   --only-private        only consider private repositories
   --organization <org>  the organization to restrict to
+  --prefix              only consider repos with a specific prefix
   --min-months <n>      the minimum number of months since a repository was updated. Others will be hidden from the list
   -h, --help            output usage information
 ```

--- a/src/cli/checkConfig.js
+++ b/src/cli/checkConfig.js
@@ -52,6 +52,11 @@ const OPTIONS = {
       return input || true; // FIXME
     },
   },
+  prefix: {
+    validate(input) {
+      return input || true; // FIXME
+    },
+  },
   repositories: {
     validate(input) {
       return input || true; // FIXME

--- a/src/cli/githubRepositoriesArchiver.js
+++ b/src/cli/githubRepositoriesArchiver.js
@@ -63,13 +63,13 @@ function githubRepositoriesArchiver(archivePath, options) {
 
         const config = {
           organization: options.organization,
+          prefix: options.prefix,
           minMonths: Number(options.minMonths) || 0,
           dryRun: options.dryRun === true,
           onlyAdmin: options.onlyAdmin === true,
           onlyPrivate: options.onlyPrivate === true,
           path: archivePath ? path.resolve(archivePath) : '',
         };
-
         checkConfig(config);
 
         config.gh = gh;
@@ -86,6 +86,11 @@ function githubRepositoriesArchiver(archivePath, options) {
           if (config.onlyPrivate && !e.private) {
             return results;
           }
+
+          if (config.prefix && !e.full_name.includes(`/${config.prefix}`)) {
+            return results;
+          }
+
           const numberOfMonthsSinceUpdated = moment.duration(moment().diff(moment(e.updated_at))).asMonths();
           if (numberOfMonthsSinceUpdated < config.minMonths) {
             return results;

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -22,6 +22,7 @@ program
   .option('--login', 'force login to happen again')
   .option('--only-admin', 'only consider repositories you can delete')
   .option('--only-private', 'only consider private repositories')
+  .option('--prefix <prefix>', 'only consider repos with a specific prefix')
   .option('--organization <org>', 'the organization to restrict to')
   .option(
     '--min-months <n>',


### PR DESCRIPTION
Hello @redox 

I would like to add more filter options, starting with a "prefix", to be able to filter repos's name on it.

**use**
```sh
yarn start -- ~/path/to/archive --organization algolia --prefix demo
```

Let me know what you think :)